### PR TITLE
Send SIGILL signal on Hypervisor Emulation Assistance interrupt

### DIFF
--- a/sys/powerpc/powerpc/trap.c
+++ b/sys/powerpc/powerpc/trap.c
@@ -294,6 +294,7 @@ trap(struct trapframe *frame)
 			break;
 
 		case EXC_FAC:
+		case EXC_HEA:
 			sig = SIGILL;
 			ucode =	ILL_ILLOPC;
 			break;


### PR DESCRIPTION
According to Power ISA:

> A Hypervisor Emulation Assistance interrupt is gener-
ated when execution is attempted of an illegal instruc-
tion, or of a reserved instruction or an instruction that is
not provided by the implementation.
> 

Currently HEA interrupt is unhandled. Handle it the same way as Facility Unavailable Interrupt - send SIGILL to userspace. 